### PR TITLE
fix `;festive` was included on all sku

### DIFF
--- a/bptf-misc-utils.user.js
+++ b/bptf-misc-utils.user.js
@@ -110,8 +110,7 @@
     let isStrange = item.attr("data-quality_elevated") === "11";
     let itemKillstreak = item.attr("data-ks_tier");
     let isFestivized =
-      item.attr("data-original-title")?.toLowerCase().indexOf("festivized") !==
-      -1;
+      item.attr("data-original-title") ? item.attr("data-original-title").toLowerCase().indexOf("festivized") !== -1 : false;
     let isAustralium = item.attr("data-australium") === "1";
 
     // Other item attributes


### PR DESCRIPTION
because when `item.attr("data-original-title")` is `undefined`, the left side will be `undefined`, and `undefined !== -1` is always `true`.

![image](https://user-images.githubusercontent.com/47635037/123527912-0a7abb80-d716-11eb-9a2b-6876957f5a7f.png)
![image](https://user-images.githubusercontent.com/47635037/123527914-0e0e4280-d716-11eb-8560-43ad2534176b.png)
